### PR TITLE
integration-test-runner to support single line syntax for cherry-picking

### DIFF
--- a/cherrypicks.go
+++ b/cherrypicks.go
@@ -24,7 +24,7 @@ func getLatestIntegrationRelease(number int, conf *config) ([]string, error) {
 	cmd := fmt.Sprintf(
 		"git for-each-ref --sort=-creatordate --format='%%(refname:short)' 'refs/tags' "+
 			"| sed -E '/(^[0-9]+\\.[0-9]+)\\.[0-9]+$/!d;s//\\1.x/' |  uniq "+
-			"| head -n %d | sort -V -r",
+			"| head -n 4 | sort -V -r | head -n %d",
 		number,
 	)
 	c := exec.Command("sh", "-c", cmd)

--- a/cherrypicks.go
+++ b/cherrypicks.go
@@ -23,7 +23,7 @@ var errorCherryPickConflict = errors.New("Cherry pick had conflicts")
 func getLatestIntegrationRelease(number int, conf *config) ([]string, error) {
 	cmd := fmt.Sprintf(
 		"git for-each-ref --sort=-creatordate --format='%%(refname:short)' 'refs/tags' "+
-			"| sed -E '/(^[0-9]+\\.[0-9]+)\\.[0-9]+$/!d;s//\\1.x/' | grep -vF 2.7.x | uniq "+
+			"| sed -E '/(^[0-9]+\\.[0-9]+)\\.[0-9]+$/!d;s//\\1.x/' |  uniq "+
 			"| head -n %d | sort -V -r",
 		number,
 	)

--- a/cherrypicks_test.go
+++ b/cherrypicks_test.go
@@ -91,7 +91,7 @@ func TestSuggestCherryPicks(t *testing.T) {
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
-2.2.x (release 3.2.x)
+2.1.x (release 3.1.x)
 2.0.x (release 3.0.x)
 1.3.x (release 2.6.x)
 `),
@@ -115,7 +115,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
-2.0.x (release 3.2.x)
+1.2.x (release 3.1.x)
 1.2.x (release 3.0.x)
 1.0.x (release 2.6.x)
 `),
@@ -139,7 +139,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
-2.0.x (release 3.2.x)
+1.2.x (release 3.1.x)
 1.2.x (release 3.0.x)
 1.0.x (release 2.6.x)
 `),
@@ -167,7 +167,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
-3.2.x (release 3.2.x)
+3.1.x (release 3.1.x)
 3.0.x (release 3.0.x)
 2.5.x (release 2.6.x)
 `),
@@ -192,7 +192,6 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 		t.Run(name, func(t *testing.T) {
 			mclient := &mock_github.Client{}
 			defer mclient.AssertExpectations(t)
-
 			if test.comment != nil {
 				mclient.On("CreateComment",
 					mock.MatchedBy(func(ctx context.Context) bool {

--- a/cherrypicks_test.go
+++ b/cherrypicks_test.go
@@ -91,9 +91,9 @@ func TestSuggestCherryPicks(t *testing.T) {
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+2.2.x (release 3.2.x)
 2.1.x (release 3.1.x)
 2.0.x (release 3.0.x)
-1.3.x (release 2.6.x)
 `),
 			},
 		},
@@ -115,9 +115,9 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+2.0.x (release 3.2.x)
 1.2.x (release 3.1.x)
 1.2.x (release 3.0.x)
-1.0.x (release 2.6.x)
 `),
 			},
 		},
@@ -139,9 +139,9 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+2.0.x (release 3.2.x)
 1.2.x (release 3.1.x)
 1.2.x (release 3.0.x)
-1.0.x (release 2.6.x)
 `),
 			},
 		},
@@ -167,9 +167,9 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+3.2.x (release 3.2.x)
 3.1.x (release 3.1.x)
 3.0.x (release 3.0.x)
-2.5.x (release 2.6.x)
 `),
 			},
 		},

--- a/main_comment_test.go
+++ b/main_comment_test.go
@@ -349,6 +349,23 @@ func TestParsePrOptions(t *testing.T) {
 				"mender":         "3.1.x",
 			},
 		},
+		"start pipeline with --pr flags (new syntax)": {
+			StartPipelineComment: "start pipeline --pr mender-connect/pull/88 --pr deviceconnect/pull/12 --pr mender/3.1.x --pr deviceauth/feature-branch",
+			RepoToPr: map[string]string{
+				"mender-connect": "pull/88/head",
+				"deviceconnect":  "pull/12/head",
+				"mender":         "3.1.x",
+				"deviceauth":     "feature-branch",
+			},
+		},
+		"start pipeline with --pr flags (syntax without 'pull' and 'head')": {
+			StartPipelineComment: "start pipeline --pr mender-connect/88 --pr deviceconnect/12 --pr mender/3.1.x",
+			RepoToPr: map[string]string{
+				"mender-connect": "pull/88/head",
+				"deviceconnect":  "pull/12/head",
+				"mender":         "3.1.x",
+			},
+		},
 		"start pipeline with --pr flags and some sugar with multiple spaces": {
 			StartPipelineComment: "start pipeline  --pr          mender-connect/pull/88/head          --pr          deviceconnect/pull/12/head --pr mender/3. 1.x     sugar pretty please",
 			RepoToPr: map[string]string{
@@ -374,10 +391,12 @@ func TestParsePrOptions(t *testing.T) {
 		"start pipeline incomplete --pr param": {
 			StartPipelineComment: "start pipeline --pr some",
 			RepoToPr:             map[string]string{},
+			ParseError:           errors.New("parse error near 'some', I need, e.g.: start pipeline --pr somerepo/pull/12/head --pr somerepo/1.0.x "),
 		},
 		"start pipeline incomplete --pr params": {
 			StartPipelineComment: "start pipeline --pr --pr a --pr some",
-			RepoToPr:             map[string]string{},
+			RepoToPr:             nil,
+			ParseError:           errors.New("parse error near 'some', I need, e.g.: start pipeline --pr somerepo/pull/12/head --pr somerepo/1.0.x "),
 		},
 	}
 

--- a/util.go
+++ b/util.go
@@ -50,7 +50,7 @@ func getGitHubOrganization(webhookType string, webhookEvent interface{}) (string
 		return comment.GetRepo().GetOwner().GetLogin(), nil
 	}
 	return "", fmt.Errorf(
-		"getGitHubOrganization cannot get organizatoin from webhook type %q",
+		"getGitHubOrganization cannot get organization from webhook type %q",
 		webhookType,
 	)
 


### PR DESCRIPTION
Currently, our test-bot (integration-test-runner) repository does only support the syntax:

@mender-test-bot
cherry-pick to:

* master
* hosted

This PR enables support for one-liner syntax:

 ``@mender-test-bot cherry-pick to `master` `hosted` ``